### PR TITLE
Check TFT app version and exit if it's outdated

### DIFF
--- a/alune/adb.py
+++ b/alune/adb.py
@@ -29,7 +29,7 @@ class ADB:
         """
         Initiates base values for the ADB instance.
         """
-        self._tft_package_name = "com.riotgames.league.teamfighttactics"
+        self.tft_package_name = "com.riotgames.league.teamfighttactics"
         self._tft_activity_name = "com.riotgames.leagueoflegends.RiotNativeActivity"
         self._random = random.Random()
         self._rsa_signer = None
@@ -206,7 +206,7 @@ class ADB:
         Returns:
             Whether the TFT package is in the list of the installed packages.
         """
-        shell_output = await self._device.shell(f"pm list packages {self._tft_package_name}")
+        shell_output = await self._device.shell(f"pm list packages {self.tft_package_name}")
         return shell_output != ""
 
     async def is_tft_active(self) -> bool:
@@ -217,10 +217,21 @@ class ADB:
              Whether TFT is the currently active window.
         """
         shell_output = await self._device.shell("dumpsys window | grep -E 'mCurrentFocus' | awk '{print $3}'")
-        return shell_output.split("/")[0].replace("\n", "") == self._tft_package_name
+        return shell_output.split("/")[0].replace("\n", "") == self.tft_package_name
 
     async def start_tft_app(self):
         """
         Start TFT using the activity manager (am).
         """
-        await self._device.shell(f"am start -n {self._tft_package_name}/{self._tft_activity_name}")
+        await self._device.shell(f"am start -n {self.tft_package_name}/{self._tft_activity_name}")
+
+    async def get_tft_version(self) -> str:
+        """
+        Get the version of the TFT package.
+
+        Returns:
+            The versionName of the tft package.
+        """
+        return await self._device.shell(
+            f"dumpsys package {self.tft_package_name} | grep versionName | sed s/[[:space:]]*versionName=//g"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "adb-shell[async]==0.4.4",
     "numpy==1.26.4",
     "opencv-python==4.9.0.80",
+    "google-play-scraper==1.2.6",
     "loguru==0.7.2",
 ]
 


### PR DESCRIPTION
Changes:
- Adds the python package `google-play-scraper` to the dependencies
- Uses `google-play-scraper` to get the latest TFT app version from Google Play
- Uses adb to get the current TFT app version
- Compares the versions, and if the Google Play version is newer than the current one, exits with a message to update (and why to update)
- Makes `tft_package_name` public, so we can access it more easily - Should probably have some globals/constants somewhere eventually
- Adds more debug lines to which precondition we're checking, to determine if we get stuck on some step
- Removes the TODO of updating via APKMirror, it's simply not worth the effort