### PR TITLE
Add a configuration file and apply configuration in code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ dist/
 
 # Project specific files
 adb_key*
-logs/
+alune-output/

--- a/Alune.spec
+++ b/Alune.spec
@@ -5,7 +5,7 @@ a = Analysis(
     ['main.py'],
     pathex=[],
     binaries=[],
-    datas=[('alune/images', 'alune/images')],
+    datas=[('alune/images', 'alune/images'), ('alune/resources', 'alune/resources')],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ We will never support playing ranked with it. We also do not encourage you to le
 
 You can find planned and potential future features on our [Features wiki page](https://github.com/TeamFightTacticsBots/Alune/wiki/Features).
 
+The TFT bot is available as a Windows executable for convenience. Running from source is supported as well.
+
 ## Setup
 
 ### Android Emulator
@@ -78,15 +80,16 @@ You can find planned and potential future features on our [Features wiki page](h
 
 1. Run the downloaded `Alune.exe`. 
 
-For bug reports, logs can be found in the `logs` folder in the same folder as the `.exe` after the first run.
+The configuration for the bot can be found in the `alune-output` folder that's created during the first run.
+Logs for bug reports can be found in the `logs` folder in that output folder.
 
 ### Bot (source)
 
-1. If not already active, activate the virtual environment - see setup step 6.  
+1. If not already active, activate the virtual environment - see setup step 7.  
    1. If you use PyCharm or VS Code, you can use the in-built terminal, which does this automatically for you.
 2. Run `python main.py`
 
-For bug reports, logs can be found in the `logs` folder in the project folder after the first run.
+Same as with the executable, configuration and logs are in the `alune-output` folder.
 
 ## Development
 

--- a/alune/adb.py
+++ b/alune/adb.py
@@ -36,12 +36,15 @@ class ADB:
         self._rsa_signer = None
         self._device = None
 
-    async def load(self):
+    async def load(self, port: int):
         """
         Load the RSA signer and attempt to connect to a device via ADB TCP.
+
+        Args:
+            port: The port to attempt to connect to.
         """
         await self._load_rsa_signer()
-        await self._connect_to_device()
+        await self._connect_to_device(port)
 
     async def _load_rsa_signer(self):
         """
@@ -62,11 +65,10 @@ class ADB:
 
         self._rsa_signer = PythonRSASigner(pub=public_key, priv=private_key)
 
-    async def _connect_to_device(self, port: int = 5555):
+    async def _connect_to_device(self, port: int):
         """
         Connect to the device via TCP.
         """
-        # TODO Make port configurable (GUI or config.yml) or add port discovery
         device = AdbDeviceTcpAsync(host="localhost", port=port, default_transport_timeout_s=9)
         logger.info(f"Attempting to connect to ADB session with device localhost:{port}")
         try:

--- a/alune/adb.py
+++ b/alune/adb.py
@@ -13,6 +13,7 @@ from loguru import logger
 import numpy
 from numpy import ndarray
 
+from alune import helpers
 from alune.images import ClickButton
 from alune.images import ImageButton
 from alune.screen import BoundingBox
@@ -49,13 +50,14 @@ class ADB:
         if self._rsa_signer is not None:
             return
 
-        if not os.path.isfile("adb_key"):
-            keygen("adb_key")
+        adb_key_filepath = helpers.get_application_path("alune-output/adb_key")
+        if not os.path.isfile(adb_key_filepath):
+            keygen(adb_key_filepath)
 
-        with open("adb_key", encoding="utf-8") as adb_key_file:
+        with open(adb_key_filepath, encoding="utf-8") as adb_key_file:
             private_key = adb_key_file.read()
 
-        with open("adb_key.pub", encoding="utf-8") as adb_key_file:
+        with open(adb_key_filepath + ".pub", encoding="utf-8") as adb_key_file:
             public_key = adb_key_file.read()
 
         self._rsa_signer = PythonRSASigner(pub=public_key, priv=private_key)

--- a/alune/config.py
+++ b/alune/config.py
@@ -1,0 +1,122 @@
+"""
+Module to handle the configuration for the bot.
+"""
+
+import os.path
+import shutil
+from typing import Any
+
+from loguru import logger
+from ruamel.yaml import YAML
+
+from alune import helpers
+from alune import images
+
+
+class AluneConfig:
+    """
+    Alune config class.
+    """
+    def __init__(self):
+        """
+        Writes the configuration from resource (provided in repository) to storage path, loads the configuration from
+        storage path to memory and updates the configuration if necessary.
+        """
+        yaml = YAML()
+
+        config_resource_path = helpers.get_resource_path("alune/resources/config.yaml")
+        config_path = helpers.get_application_path("alune-output/config.yaml")
+        os.makedirs(os.path.dirname(config_path), exist_ok=True)
+
+        if not os.path.isfile(config_path):
+            shutil.copyfile(config_resource_path, config_path)
+
+        with open(config_resource_path, mode="r", encoding="UTF-8") as config_resource:
+            _config_resource: dict[str, Any] = yaml.load(config_resource)
+
+        with open(config_path, mode="r", encoding="UTF-8") as config_file:
+            self._config = yaml.load(config_file)
+
+        if _config_resource.get("version") > self._config.get("version", 0):
+            logger.warning("Config is outdated, creating a back-up and updating it.")
+
+            shutil.copyfile(config_path, f"{config_path}.bak")
+
+            if _config_resource.get("set") > self._config.get("set", 11):
+                logger.warning("There is a new set, updating traits as well.")
+                self._config["traits"] = _config_resource["traits"]
+
+            _config_resource.update(
+                (key, self._config[key]) for key in self._config.keys() & _config_resource.keys() if key != "version"
+            )
+            with open(config_path, mode="w", encoding="UTF-8") as config_file:
+                yaml.dump(_config_resource, config_file)
+
+            self._config = _config_resource
+
+        self._sanitize()
+
+    def _sanitize(self):
+        """
+        Calls all sanitize methods.
+        If necessary, user configured values will be overridden with a valid value (in memory, not in the file).
+        The user should be notified of any invalid configurations.
+        """
+        self._sanitize_log_level()
+        self._sanitize_traits()
+
+    def _sanitize_log_level(self):
+        """
+        Sanitize the user configured log level by checking against valid values.
+        """
+        log_level = self._config.get("log_level", "INFO").upper()
+        if log_level not in {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}:
+            logger.warning(f"The configured log level '{log_level}' does not exist. Using INFO instead.")
+            self._config["log_level"] = "INFO"
+
+    def _sanitize_traits(self):
+        """
+        Sanitize the user configured traits by checking against currently implemented traits.
+        """
+        current_traits = [trait.name for trait in list(images.Trait)]
+        configured_traits = self._config.get("traits", [])
+
+        allowed_traits = []
+        for trait in configured_traits:
+            if trait.upper() not in current_traits:
+                logger.warning(f"The configured trait '{trait}' does not exist. Skipping it.")
+                continue
+            allowed_traits.append(images.Trait[trait.upper()])
+
+        if len(allowed_traits) == 0:
+            logger.warning(f"No valid traits were configured. Falling back to {images.Trait.get_default_traits()}.")
+            allowed_traits = images.Trait.get_default_traits()
+
+        self._config["traits"] = allowed_traits
+
+    def get_log_level(self) -> str:
+        """
+        Get the level we're supposed to log at from the config.
+
+        Returns:
+            The configured level as a str.
+        """
+        return self._config["log_level"]
+
+    def get_adb_port(self) -> int:
+        """
+        Get the adb port the user wants us to connect to.
+
+        Returns:
+            The port to attempt a connection to.
+        """
+        return self._config.get("adb_port", 5555)
+
+    def get_traits(self) -> list[images.Trait]:
+        """
+        Get the list of traits we attempt to purchase.
+
+        Returns:
+            A list of traits we look for.
+        """
+        return self._config["traits"]

--- a/alune/config.py
+++ b/alune/config.py
@@ -17,6 +17,7 @@ class AluneConfig:
     """
     Alune config class.
     """
+
     def __init__(self):
         """
         Writes the configuration from resource (provided in repository) to storage path, loads the configuration from

--- a/alune/images.py
+++ b/alune/images.py
@@ -153,6 +153,16 @@ class Trait(StrEnum):
     def _generate_next_value_(name, start, count, last_values):
         return helpers.get_resource_path(f"alune/images/traits/{name.lower()}.png")
 
+    @classmethod
+    def get_default_traits(cls):
+        """
+        Gets a list of default traits the bot should use.
+
+        Returns:
+            A list of the traits to be played by default, if the user misconfigures.
+        """
+        return [cls.HEAVENLY]
+
     HEAVENLY = auto()
 
 

--- a/alune/resources/config.yaml
+++ b/alune/resources/config.yaml
@@ -1,0 +1,22 @@
+# The level to log information at. The higher the level, the less you will see.
+# We do not recommend setting it higher than WARNING, but support it.
+# Valid levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
+log_level: "INFO"
+
+# The ADB port your emulator is open on.
+# Should be 5555 in most cases. If you're unable to get this to work,
+# visit https://github.com/TeamFightTacticsBots/Alune/wiki/ADB-Port for more information.
+adb_port: 5555
+
+# The traits you want the bot to roll for.
+# The trait names are almost as written in-game, with spaces replaced by _ and . and : being ignored.
+# For example: admin, star_guardian, mecha_prime, lasercorps
+# For a full list of valid traits, visit https://github.com/TeamFightTacticsBots/Alune/tree/main/alune/images/traits
+traits:
+  - heavenly
+
+# Changing these below values manually can potentially break the bot, so don't!
+# Version of the YAML.
+version: 1
+# Version of the TFT set.
+set: 11

--- a/main.py
+++ b/main.py
@@ -371,9 +371,8 @@ async def main():
     Main method, loads ADB connection, checks if the phone is ready to be used and
     finally loops the main app loop in a device disconnect catch wrapper.
     """
-    logs_path = helpers.get_application_path("logs")
-    if not os.path.exists(logs_path):
-        os.mkdir(logs_path)
+    logs_path = helpers.get_application_path("alune-output/logs")
+    os.makedirs(logs_path, exist_ok=True)
     logger.add(logs_path + "/{time}.log", level="DEBUG", retention=10)
 
     await check_version()

--- a/main.py
+++ b/main.py
@@ -359,7 +359,7 @@ async def check_version():
                     "A newer version is available. "
                     "You can download it at https://github.com/TeamFightTacticsBots/Alune/releases/latest"
                 )
-        return
+                return
     except HTTPError:
         logger.debug("Remote is not reachable, assuming local is newer.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alune"
-version = "0.0.2"
+version = "0.1.0"
 authors = [
   {name = "akshualy"},
   {name = "Detergent13"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "opencv-python==4.9.0.80",
     "google-play-scraper==1.2.6",
     "loguru==0.7.2",
+    "ruamel.yaml==0.18.6",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alune"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
   {name = "akshualy"},
   {name = "Detergent13"},


### PR DESCRIPTION
Resolves #3 

Changes:
- Added `ruamel.yaml` package to parse YAML files
- Moved all output to a centralized `alune-output` folder. This folder now holds logs, adb RSA keys and the config.
- Added a class method to the traits enum to define default traits dynamically
- Created a config class that loads `config.yaml`, which is able to self-update with the help of a version number in it
- User-entered config values will be sanitized/checked
- Added code and config for
    - The terminal log level, the log file output will always happen at `DEBUG`
    - The adb port
    - The traits the bot will purchase
- Fixed a return statement indentation issue in the version check
- Bumped version - I'm honestly not sure how we want to bump versions. Do we just follow semantic? I'm happy to bump minor instead of patch.

I also added a wiki page about the [ADB port](https://github.com/TeamFightTacticsBots/Alune/wiki/ADB-Port).