### PR TITLE
Fix mode selection

### DIFF
--- a/alune/screen.py
+++ b/alune/screen.py
@@ -86,8 +86,8 @@ def get_on_screen(
         return None
 
     return ImageSearchResult(
-        x=max_location[0] + bounding_box.min_x if bounding_box else 0,
-        y=max_location[1] + bounding_box.min_y if bounding_box else 0,
+        x=max_location[0] + (bounding_box.min_x if bounding_box else 0),
+        y=max_location[1] + (bounding_box.min_y if bounding_box else 0),
         height=image_to_find.shape[0],
         width=image_to_find.shape[1],
     )


### PR DESCRIPTION
Fixes mode selection by clicking the recognized "normal mode" image. Event modes apparently take up the first slot instead sometimes and the bot picked those instead..