### PR TITLE
Scan localhost ADB ports

### DIFF
--- a/alune/adb.py
+++ b/alune/adb.py
@@ -79,6 +79,10 @@ class ADB:
         connections = [
             conn for conn in psutil.net_connections("tcp4") if conn.laddr.port >= 5555 and conn.status == "LISTEN"
         ]
+
+        if len(connections) > 9:
+            logger.warning(f"There are {len(connections)} open ports, scanning may take a while.")
+
         for conn in connections:
             logger.debug(f"Scanning port {conn.laddr.port} for ADB...")
             try:

--- a/alune/config.py
+++ b/alune/config.py
@@ -48,6 +48,7 @@ class AluneConfig:
 
             if _config_resource.get("set") > self._config.get("set", 11):
                 logger.warning("There is a new set, updating traits as well.")
+                self._config["set"] = _config_resource["set"]
                 self._config["traits"] = _config_resource["traits"]
 
             _config_resource.update(

--- a/alune/resources/config.yaml
+++ b/alune/resources/config.yaml
@@ -3,11 +3,6 @@
 # Valid levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
 log_level: "INFO"
 
-# The ADB port your emulator is open on.
-# Should be 5555 in most cases. If you're unable to get this to work,
-# visit https://github.com/TeamFightTacticsBots/Alune/wiki/ADB-Port for more information.
-adb_port: 5555
-
 # The traits you want the bot to roll for.
 # The trait names are almost as written in-game, with spaces replaced by _ and . and : being ignored.
 # For example: admin, star_guardian, mecha_prime, lasercorps

--- a/main.py
+++ b/main.py
@@ -145,7 +145,7 @@ async def check_surrender_state(adb_instance: ADB, screenshot: ndarray, config: 
         config: An instance of the alune config to use.
 
     Returns:
-        Whether or not we're able to surrender.
+        Whether we're able to surrender.
     """
     if not config.should_surrender():
         return False
@@ -157,7 +157,7 @@ async def check_surrender_state(adb_instance: ADB, screenshot: ndarray, config: 
     surrender_delay = config.get_surrender_delay()
     logger.info(f"Surrendering the game in {surrender_delay} seconds.")
     await asyncio.sleep(surrender_delay)
-    surrender_game(adb_instance)
+    await surrender_game(adb_instance)
     return True
 
 

--- a/main.py
+++ b/main.py
@@ -476,6 +476,7 @@ async def main():
     await check_version()
 
     adb_instance = ADB()
+
     await adb_instance.load(config.get_adb_port())
     if not adb_instance.is_connected():
         logger.error("There is no ADB device ready. Exiting.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "google-play-scraper==1.2.6",
     "loguru==0.7.2",
     "ruamel.yaml==0.18.6",
+    "psutil==6.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Feature that scans localhost for ports by attempting a quick half-second connection to every listening port.
Removed the adb setting from the config.
Fixed an issue where the set number would not update in the config.
Fixed missing await on surrender game.