### PR TITLE
Add Keyboard Shortcuts For Pausing Game & Not Requeuing Next Match

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ import json
 import os
 from random import Random
 import sys
-import time
 from urllib.error import HTTPError
 from urllib.error import URLError
 import urllib.request
@@ -298,10 +297,10 @@ async def loop(adb_instance: ADB, config: AluneConfig):
         config: An instance of the alune config to use.
     """
     while True:
-        delay_next_game()
+        await delay_next_game()
 
         if PAUSE_LOGIC:
-            time.sleep(5)
+            await asyncio.sleep(5)
             continue
 
         if not await adb_instance.is_tft_active():
@@ -344,7 +343,7 @@ async def loop(adb_instance: ADB, config: AluneConfig):
                 search_result = screen.get_button_on_screen(screenshot, Button.exit_now)
                 while not search_result:
                     if PAUSE_LOGIC:
-                        time.sleep(5)
+                        await asyncio.sleep(5)
                         continue
 
                     await take_game_decision(adb_instance, config)
@@ -511,7 +510,7 @@ async def main():
     await loop_disconnect_wrapper(adb_instance, config)
 
 
-def delay_next_game():
+async def delay_next_game():
     """
     Checks whether to delay the next game based on the PLAY_NEXT_GAME variable
     """
@@ -521,7 +520,7 @@ def delay_next_game():
         # Don't print it every iteration
         if wait_counter > 0 and (sleep_time * wait_counter) % 30 == 0:
             logger.debug(f"Play next game still disabled after {sleep_time * wait_counter} seconds")
-        time.sleep(sleep_time)
+        await asyncio.sleep(sleep_time)
         wait_counter = wait_counter + 1
 
 

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ from alune.screen import ImageSearchResult
 PAUSE_LOGIC = False
 PLAY_NEXT_GAME = True
 
+
 class GameState(StrEnum):
     """
     State the game or app is in.
@@ -287,6 +288,7 @@ async def loop_disconnect_wrapper(adb_instance: ADB, config: AluneConfig):
         logger.info("Reconnected to device, continuing main loop.")
         await loop_disconnect_wrapper(adb_instance, config)
 
+
 async def loop(adb_instance: ADB, config: AluneConfig):
     """
     The main app loop logic.
@@ -508,6 +510,7 @@ async def main():
 
     await loop_disconnect_wrapper(adb_instance, config)
 
+
 def delay_next_game():
     """
     Checks whether to delay the next game based on the PLAY_NEXT_GAME variable
@@ -521,13 +524,14 @@ def delay_next_game():
         time.sleep(sleep_time)
         wait_counter = wait_counter + 1
 
+
 def toggle_pause() -> None:
     """
     Toggles whether the bots logic evaluation should pause.
     *Note:* This does not entirely stop the bot, but does stop various state changes that can be annoying if you're
     trying to manually interact with it.
     """
-    global PAUSE_LOGIC # pylint: disable=global-statement
+    global PAUSE_LOGIC  # pylint: disable=global-statement
     logger.debug(f"alt+p pressed, toggling pause from {PAUSE_LOGIC} to {not PAUSE_LOGIC}")
     PAUSE_LOGIC = not PAUSE_LOGIC
     if PAUSE_LOGIC:
@@ -541,7 +545,7 @@ def toggle_play_next_game() -> None:
     Toggles whether the bots logic evaluation should start a new game after this finishes.
     *Note:* This does not entirely stop the bot, but will stop it from starting a new game.
     """
-    global PLAY_NEXT_GAME # pylint: disable=global-statement
+    global PLAY_NEXT_GAME  # pylint: disable=global-statement
     logger.debug(f"alt+n pressed, toggling pause from {PLAY_NEXT_GAME} to {not PLAY_NEXT_GAME}")
     PLAY_NEXT_GAME = not PLAY_NEXT_GAME
     if not PLAY_NEXT_GAME:
@@ -549,12 +553,14 @@ def toggle_play_next_game() -> None:
     else:
         logger.warning("Bot will queue a new game when in lobby!")
 
+
 def setup_hotkeys() -> None:
     """
     Setup hotkey listeners
     """
     keyboard.add_hotkey("alt+p", lambda: toggle_pause())  # pylint: disable=unnecessary-lambda
     keyboard.add_hotkey("alt+n", lambda: toggle_play_next_game())  # pylint: disable=unnecessary-lambda
+
 
 if __name__ == "__main__":
     try:

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ from enum import StrEnum
 import importlib.metadata
 import json
 import time
-import keyboard
 import os
 from random import Random
 import sys
@@ -20,6 +19,7 @@ import urllib.request
 from adb_shell.exceptions import TcpTimeoutException
 import google_play_scraper
 from loguru import logger
+import keyboard
 from numpy import ndarray
 
 from alune import helpers
@@ -509,6 +509,9 @@ async def main():
     await loop_disconnect_wrapper(adb_instance, config)
 
 def delay_next_game():
+    """
+    Checks whether to delay the next game based on the PLAY_NEXT_GAME variable
+    """
     wait_counter = 0
     while not PLAY_NEXT_GAME:
         sleep_time = 15
@@ -524,7 +527,7 @@ def toggle_pause() -> None:
     *Note:* This does not entirely stop the bot, but does stop various state changes that can be annoying if you're
     trying to manually interact with it.
     """
-    global PAUSE_LOGIC
+    global PAUSE_LOGIC # pylint: disable=global-statement
     logger.debug(f"alt+p pressed, toggling pause from {PAUSE_LOGIC} to {not PAUSE_LOGIC}")
     PAUSE_LOGIC = not PAUSE_LOGIC
     if PAUSE_LOGIC:
@@ -538,7 +541,7 @@ def toggle_play_next_game() -> None:
     Toggles whether the bots logic evaluation should start a new game after this finishes.
     *Note:* This does not entirely stop the bot, but will stop it from starting a new game.
     """
-    global PLAY_NEXT_GAME
+    global PLAY_NEXT_GAME # pylint: disable=global-statement
     logger.debug(f"alt+n pressed, toggling pause from {PLAY_NEXT_GAME} to {not PLAY_NEXT_GAME}")
     PLAY_NEXT_GAME = not PLAY_NEXT_GAME
     if not PLAY_NEXT_GAME:

--- a/main.py
+++ b/main.py
@@ -8,18 +8,18 @@ from enum import auto
 from enum import StrEnum
 import importlib.metadata
 import json
-import time
 import os
 from random import Random
 import sys
+import time
 from urllib.error import HTTPError
 from urllib.error import URLError
 import urllib.request
 
 from adb_shell.exceptions import TcpTimeoutException
 import google_play_scraper
-from loguru import logger
 import keyboard
+from loguru import logger
 from numpy import ndarray
 
 from alune import helpers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alune"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
   {name = "akshualy"},
   {name = "Detergent13"},
@@ -21,6 +21,7 @@ dependencies = [
     "loguru==0.7.2",
     "ruamel.yaml==0.18.6",
     "psutil==6.0.0",
+    "keyboard==0.13.5",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
![](https://media3.giphy.com/media/l0G188MT2Mu47nEvC/giphy.gif)

## Description
This re-adds the keyboard shortcuts functionality from https://github.com/Kyrluckechuck/TFT-Bot, adding initially just two functions:
- To pause the bot so that the "next" action won't occur
- To stop the bot from re-queing next game, which is useful for if you want it to finish up the game but not start another so you can use it, etc.

I'm open to suggestions on cleaner implementations, but basically just ripped it right out of the old bot for simplicity 😅 