### PR TITLE
Remove delay of getting device screen

### DIFF
--- a/alune/adb.py
+++ b/alune/adb.py
@@ -119,7 +119,7 @@ class ADB:  # pylint: disable=too-many-instance-attributes
         if self._is_screen_recording:
             self._should_stop_screen_recording = True
 
-    def _create_screen_record_task(self):
+    def create_screen_record_task(self):
         """
         Create the screen recording task. Will not start recording if there's already a recording.
         """
@@ -139,7 +139,6 @@ class ADB:  # pylint: disable=too-many-instance-attributes
             connection = await device.connect(rsa_keys=[self._rsa_signer], auth_timeout_s=1)
             if connection:
                 self._device = device
-                self._create_screen_record_task()
                 return
         except OSError:
             self._device = None
@@ -214,9 +213,9 @@ class ADB:  # pylint: disable=too-many-instance-attributes
         """
         if self._config.should_use_screen_record():
             return self._latest_frame
-        return await self.get_screen_capture()
+        return await self._get_screen_capture()
 
-    async def get_screen_capture(self) -> ndarray | None:
+    async def _get_screen_capture(self) -> ndarray | None:
         """
         Gets a ndarray which contains the values of the gray-scaled pixels
         currently on the screen. Uses screencap, so will take some processing time.

--- a/alune/config.py
+++ b/alune/config.py
@@ -212,3 +212,12 @@ class AluneConfig:
             The queue timeout in seconds.
         """
         return self._config["queue_timeout"]
+
+    def should_use_screen_record(self) -> bool:
+        """
+        Get the screen record setting the user wants.
+
+        Returns:
+            Whether we should use screen recording.
+        """
+        return self._config["screen_record"]["enabled"]

--- a/alune/resources/config.yaml
+++ b/alune/resources/config.yaml
@@ -44,6 +44,6 @@ adb_port: 5555
 
 # Changing these below values manually can potentially break the bot, so don't!
 # Version of the YAML.
-version: 7
+version: 8
 # Version of the TFT set.
 set: 13

--- a/alune/resources/config.yaml
+++ b/alune/resources/config.yaml
@@ -31,6 +31,14 @@ surrender_early: false
 # Default value : 0 (disabled = surrender as fast as possible)
 surrender_random_delay: 0
 
+# Screen recording settings.
+screen_record:
+  # Whether we should use screen recording.
+  # If false, the bot will fall back to screen capture.
+  # Screen recording saves ~600ms per screen check, but may occasionally cause a timeout.
+  # The timeout will be caught and handled.
+  enabled: true
+
 # Configuration for chance events in the bot, in percent.
 chances:
   # The chance % to buy experience per check - configuring 50 means it's a 50% chance.
@@ -44,6 +52,6 @@ adb_port: 5555
 
 # Changing these below values manually can potentially break the bot, so don't!
 # Version of the YAML.
-version: 8
+version: 9
 # Version of the TFT set.
 set: 13

--- a/main.py
+++ b/main.py
@@ -548,6 +548,12 @@ async def main():
 
     logger.debug("ADB is connected, checking phone and app details")
     await check_phone_preconditions(adb_instance)
+
+    while await adb_instance.get_screen() is None:
+        logger.debug("Waiting for frame data to become available...")
+        await asyncio.sleep(0.5)
+    logger.debug("Frames are now available.")
+
     logger.info("Connected to ADB and device is set up correctly, starting main loop.")
 
     if config.should_surrender():

--- a/main.py
+++ b/main.py
@@ -291,7 +291,9 @@ async def loop_disconnect_wrapper(adb_instance: ADB, config: AluneConfig):
         await loop(adb_instance, config)
     except TcpTimeoutException:
         logger.warning("ADB device was disconnected, attempting one reconnect...")
+        adb_instance.mark_screen_record_for_close()
         await adb_instance.load()
+        adb_instance.create_screen_record_task()
         if not adb_instance.is_connected():
             raise_and_exit("Could not reconnect. Please check your emulator for any errors. Exiting.")
         logger.info("Reconnected to device, continuing main loop.")
@@ -551,6 +553,7 @@ async def main():
 
     if config.should_use_screen_record():
         logger.info("The bot will use live screen recording for image searches.")
+        adb_instance.create_screen_record_task()
         while await adb_instance.get_screen() is None:
             logger.debug("Waiting for frame data to become available...")
             await asyncio.sleep(0.5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "psutil==6.0.0",
     "keyboard==0.13.5",
     "imutils==0.5.4",
+    "av==14.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Implements screen recording to get live image data from the device. We record at ~30-60fps depending on device.

Normally, screen recording keeps the shell busy due to the constant stream of bytes. We work around that by loading off the recording and decoding into a separate asyncio task.
The shell may still be overwhelmed at times (usually roughly once an hour) and time out, but we have a catch mechanism in place and the session restarts properly.

While the implemented solution seems stable, I added the config option to disable this feature.
In the future, I know of a second workaround which reduces timeouts, but this needs a bigger code refactor to be properly implemented.